### PR TITLE
herokuデプロイエラー復旧-1

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module FocusON
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.assets.initialize_on_precompile = false
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "FocusON",
+  "name": "focus_on",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.1",


### PR DESCRIPTION
### What
application.rbにおいて**config.assets.initialize_on_precompile = false**を記述

### Why
デプロイから復旧させるため